### PR TITLE
Modify generateBoard tests to be unitary

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "build:dev": "tsc --watch",
     "test": "jest",
+    "test:dev": "jest --watchAll",
     "prepare": "husky"
   },
   "keywords": [],

--- a/src/board/__tests__/generateBoard.test.ts
+++ b/src/board/__tests__/generateBoard.test.ts
@@ -10,28 +10,51 @@ const newCell: Cell = {
 };
 
 describe("Given the generateBoard function", () => {
-  /* describe("When it receives 5", () => {
-    test(`Then it should return
-      [[newCell, newCell, newCell, newCell, newCell],
-      [newCell, newCell, newCell, newCell, newCell],
-      [newCell, newCell, newCell, newCell, newCell],
-      [newCell, newCell, newCell, newCell, newCell],
-      [newCell, newCell, newCell, newCell, newCell]]
-      `, () => {
+  describe("When it receives 5", () => {
+    test("Then it should return a board with 5 rows", () => {
       const boardDimension = 5;
+      const testBoard = generateBoard(boardDimension);
 
-      const expectedBoard = [
-        [newCell, newCell, newCell, newCell, newCell],
-        [newCell, newCell, newCell, newCell, newCell],
-        [newCell, newCell, newCell, newCell, newCell],
-        [newCell, newCell, newCell, newCell, newCell],
-        [newCell, newCell, newCell, newCell, newCell],
-      ];
-      const actualBoard = generateBoard(boardDimension);
+      const expectedRows = 5;
+      const actualRows = testBoard.length;
 
-      expect(expectedBoard).toStrictEqual(actualBoard);
+      expect(actualRows).toBe(expectedRows);
     });
-  }); */
+
+    test("Then it should return a board with 5 columns", () => {
+      const boardDimension = 5;
+      const testBoard = generateBoard(boardDimension);
+
+      const expectedColumns = 5;
+      const actualColumns = testBoard[0].length;
+
+      expect(actualColumns).toBe(expectedColumns);
+    });
+
+    test("Then it should return a board with no mines", () => {
+      const boardDimension = 5;
+      const testBoard = generateBoard(boardDimension);
+
+      const expectedBoolean = true;
+      const actualBoolean = testBoard.every((row) =>
+        row.every((cell) => !cell.hasMine)
+      );
+
+      expect(actualBoolean).toBe(expectedBoolean);
+    });
+
+    test("Then it should return a board with no adjacent mines", () => {
+      const boardDimension = 5;
+      const testBoard = generateBoard(boardDimension);
+
+      const expectedBoolean = true;
+      const actualBoolean = testBoard.every((row) =>
+        row.every((cell) => cell.adjacentMinesTotal === 0)
+      );
+
+      expect(actualBoolean).toBe(expectedBoolean);
+    });
+  });
 
   describe("When it receives 0", () => {
     test(`Then it should return error message "The minimum dimension to generate a board is 5"`, () => {


### PR DESCRIPTION
Modified the generateBoard tests to be unitary, every one testing a single feature of the board